### PR TITLE
supabase: Avatar uploads

### DIFF
--- a/docker/volumes/db/init/data.sql
+++ b/docker/volumes/db/init/data.sql
@@ -186,13 +186,10 @@ ALTER TABLE ONLY "public"."profiles"
 ADD CONSTRAINT "profiles_id_fkey" FOREIGN KEY ("id") REFERENCES "auth"."users"("id") ON DELETE CASCADE;
 
 -- Spotify credentials
-
-
 CREATE TABLE IF NOT EXISTS "public"."spotify_credentials" (
     "id" "uuid" NOT NULL references "auth"."users"("id") ON DELETE CASCADE references "auth"."users"("id") ON DELETE CASCADE,
     "refresh_token" "text"
 );
-
 
 ALTER TABLE "public"."spotify_credentials" OWNER TO "postgres";
 
@@ -200,3 +197,13 @@ GRANT ALL ON TABLE "public"."spotify_credentials" TO "anon";
 GRANT ALL ON TABLE "public"."spotify_credentials" TO "authenticated";
 GRANT ALL ON TABLE "public"."spotify_credentials" TO "service_role";
 
+-- Avatar images
+INSERT INTO storage.buckets
+    (id, name, public)
+VALUES
+    ('avatars', 'avatars', true);
+
+CREATE POLICY "Authenticated users can select avatars" ON storage.objects FOR SELECT TO authenticated USING (bucket_id = 'avatars');
+CREATE POLICY "Authenticated users can upload avatars" ON storage.objects FOR INSERT TO authenticated WITH CHECK (bucket_id = 'avatars');
+CREATE POLICY "Authenticated users can delete avatars" ON storage.objects FOR DELETE TO authenticated USING (bucket_id = 'avatars');
+CREATE POLICY "Authenticated users can update avatars" ON storage.objects FOR UPDATE TO authenticated USING (bucket_id = 'avatars');

--- a/docker/volumes/db/init/migration.sql
+++ b/docker/volumes/db/init/migration.sql
@@ -139,3 +139,15 @@ update test.albums set image = replace(image, '"', '') where image like '%"%';
 -- add profile theme column
 alter table public.profiles add column "theme" text;
 update public.profiles set theme = 'dark' where theme is null;
+
+-- add avatar bucket
+INSERT INTO storage.buckets
+    (id, name, public)
+VALUES
+    ('avatars', 'avatars', true);
+
+-- add policies for the avatars bucket
+CREATE POLICY "Authenticated users can select avatars" ON storage.objects FOR SELECT TO authenticated USING (bucket_id = 'avatars');
+CREATE POLICY "Authenticated users can upload avatars" ON storage.objects FOR INSERT TO authenticated WITH CHECK (bucket_id = 'avatars');
+CREATE POLICY "Authenticated users can delete avatars" ON storage.objects FOR DELETE TO authenticated USING (bucket_id = 'avatars');
+CREATE POLICY "Authenticated users can update avatars" ON storage.objects FOR UPDATE TO authenticated USING (bucket_id = 'avatars');

--- a/docker/volumes/functions/_shared/client.ts
+++ b/docker/volumes/functions/_shared/client.ts
@@ -1,4 +1,4 @@
-import { createClient } from "https://esm.sh/@supabase/supabase-js";
+import { createClient, type SupabaseClientOptions } from "https://esm.sh/@supabase/supabase-js";
 
 /**
  * Creates a Supabase client with specified authorization headers and schema.
@@ -7,13 +7,11 @@ import { createClient } from "https://esm.sh/@supabase/supabase-js";
  * @returns The Supabase client.
  */
 export async function createSbClient(authHeader?: string, schema?: string) {
-  console.log(Deno.env.toObject());
-
   // set optional supabase client options, including authorization
   // headers and specified schema (defaults to 'public')
   const global = (authHeader) ? { headers: { Authorization: authHeader } } : undefined;
   const db = (schema) ? { schema } : undefined;
-  const options = { global, db };
+  const options: SupabaseClientOptions<string> = { global, db};
     const supabase = await createClient(
         Deno.env.get("SUPABASE_URL") ?? "",
         Deno.env.get("SUPABASE_ANON_KEY") ?? "",

--- a/docker/volumes/functions/_shared/log.ts
+++ b/docker/volumes/functions/_shared/log.ts
@@ -1,0 +1,30 @@
+import { log as shared_log } from "../../../../../lib/log.ts";
+
+let log_level = 2;
+const log_level_string = Deno.env.get("LOG_LEVEL");
+if (log_level_string === undefined) {
+    console.error("!ALERT!: service: supabase - LOG_LEVEL is not set; defaulting to 2 (error)");
+} else {
+    const log_level_number = Number.parseInt(log_level_string);
+    if (isNaN(log_level_number)) {
+        console.error("!ALERT!: service: supabase - LOG_LEVEL is not a number; defaulting to 2 (error)");
+    }
+    log_level = log_level_number;
+}
+
+/**
+ * Logs a message with a specified log level.
+ * Acts as a wrapper for the shared logger, with the
+ * log level and service name populated by default.
+ * 
+ * @param level - The log level of the message to be logged.
+ * Levels correspond directly to the log levels defined
+ * in the shared logger.
+ * @param message - The log message to be recorded.
+ */
+export function log(
+    level: number,
+    message: string
+): void {
+    shared_log(level, log_level, "supabase", message);
+}

--- a/docker/volumes/functions/_shared/query.ts
+++ b/docker/volumes/functions/_shared/query.ts
@@ -1,0 +1,94 @@
+import { SupabaseClient } from "https://esm.sh/@supabase/supabase-js";
+import type { SongInfo, AlbumInfo } from "../../../../../lib/Song.ts";
+
+type dbTrack = {
+    isrc: string;
+    track_name: string;
+    track_artists: string[];
+    track_duration_ms: number;
+	spotify_id: string
+    track_albums: {
+        albums: dbAlbum[];
+    }[];
+};
+
+type dbAlbum = {
+	album_name: string;
+	num_tracks: number;
+	release_day: number;
+	release_month: number;
+	release_year: number;
+	artists: string[];
+	image: string;
+	spotify_id: string;
+    upc: string;
+};
+
+type DBData = {
+	listened_at: number,
+	tracks: unknown
+}[];
+
+/**
+ * assembles a query that can be used to gather a user's songs and associated albums
+ * @param supabase the supabase client
+ * @param userID the id to filter listening data for
+ * @returns the database query
+ */
+// deno-lint-ignore no-explicit-any
+export function constructQuery(supabase: SupabaseClient<any, string, any>, userID: string) {
+	return supabase
+	.from("played_tracks")
+	.select(`
+	  listened_at,
+	  tracks!inner( isrc, track_name, track_artists, track_duration_ms, spotify_id,
+		track_albums!inner( albums!inner( album_name, num_tracks, release_day,
+		  release_month, release_year, artists, image, spotify_id, upc ) )
+	  )
+	`)
+	.eq("user_id", userID)
+}
+
+/**
+ * processes the returned database data into an array of SongInfo objects
+ * @param dbData the data returned by running the query returned by `constructQuery()`
+ * @returns a list of SongInfo objects
+ */
+export function processPlayedTracksData(dbData: DBData): SongInfo[] {
+	const songs: SongInfo[] = []
+	for (const entry of dbData) {
+		// the supabase api thinks that tracks() and track_albums() return an array of objects,
+		// but in reality, they only return one object. as a result, we have to do some
+		// pretty ugly typecasting to make the compiler happy
+		const track = entry.tracks as dbTrack;
+		const album = track.track_albums[0].albums as unknown as dbAlbum;
+
+		// extract album information
+		const albumInfo: AlbumInfo = {
+			title: album.album_name,
+			tracks: album.num_tracks,
+			release_day: album.release_day,
+			release_month: album.release_month,
+			release_year: album.release_year,
+			artists: album.artists,
+			image: album.image,
+			spotify_id: album.spotify_id,
+            upc: album.upc
+		};
+		
+		// extract song information
+		const songInfo: SongInfo = {
+			isrc: track.isrc,
+			title: track.track_name,
+			artists: track.track_artists,
+			duration: track.track_duration_ms,
+			listened_at: entry.listened_at,
+			spotify_id: track.spotify_id,
+			albums: [albumInfo]
+		};
+		
+		songs.push(songInfo);
+	}
+
+	return songs;
+}

--- a/docker/volumes/functions/delete-avatar/index.ts
+++ b/docker/volumes/functions/delete-avatar/index.ts
@@ -1,0 +1,86 @@
+import { corsHeaders } from "../_shared/cors.ts";
+import { log } from "../_shared/log.ts";
+import { createSbClient } from "../_shared/client.ts";
+
+/**
+ * Handles requests to upload a user's avatar image to Supabase storage.
+ * Validates the uploaded file, checking its size and type.
+ * 
+ * @param _req - The request object.
+ * @returns A response object containing either a success message or an error message.
+ */
+async function handleUploadAvatar(req: Request) {
+  // create authenticated supabase client scoped to the "public" schema
+  const authHeader = req.headers.get("Authorization")!;
+  const supabase = await createSbClient(authHeader, "public");
+  
+  // get user data
+  const { data: userData } = await supabase.auth.getUser();
+  if (!userData.user) {
+    log(4, "Unable to fetch user");
+    return new Response("Unable to fetch user",
+      { status: 401, headers: corsHeaders });
+  }
+
+  // get previous avatar URL from profile data
+  const { data: profile, error: profileError } = await supabase
+    .from("profiles")
+    .select("avatar_url")
+    .eq("id", userData.user.id)
+    .single();
+  
+  if (profileError) {
+    log(2, `Error updating profile avatar URL: ${profileError.message}`);
+    return new Response("server error while fetching profile",
+      { status: 500, headers: corsHeaders },
+    );
+  }
+
+  // extract the UUID from the previous avatar URL
+  const uuid = profile?.avatar_url?.split("/").pop() || "";
+
+  if (!uuid) {
+    log(2, "No previous avatar URL found");
+    return new Response("no previous avatar URL found",
+      { status: 400, headers: corsHeaders });
+  }
+
+  // delete the previous avatar file from storage
+  const { error: deleteError } = await supabase.storage.from('avatars')
+    .remove([uuid]);
+  
+  if (deleteError) {
+    log(2, `Error deleting previous avatar: ${deleteError.message}`);
+    return new Response("server error while deleting previous avatar",
+      { status: 500, headers: corsHeaders },
+    );
+  }
+
+  // remove the avatar URL from the user's profile
+  const { error: updateError } = await supabase
+    .from("profiles")
+    .update({ avatar_url: null })
+    .eq("id", userData.user.id);
+
+  if (updateError) {
+    log(2, `Error updating profile avatar URL: ${updateError.message}`);
+    return new Response("server error while updating profile",
+      { status: 500, headers: corsHeaders },
+    );
+  }
+
+  // const { error: uploadError } = await supabase.storage.from('avatars')
+  //   .upload(uuid, avatar);
+  // if (uploadError) {
+  //   log(2, `Error uploading avatar: ${uploadError.message}`);
+  //   return new Response("server error while uploading avatar",
+  //     { status: 500, headers: corsHeaders },
+  //   );
+  // }
+
+  return new Response(
+    "successfully removed avatar",
+    { status: 200, headers: { ...corsHeaders } },
+  );
+}
+Deno.serve(handleUploadAvatar);

--- a/docker/volumes/functions/get-display-data/index.ts
+++ b/docker/volumes/functions/get-display-data/index.ts
@@ -1,7 +1,8 @@
 import { corsHeaders } from "../_shared/cors.ts";
 import { createSbClient } from "../_shared/client.ts";
-import type { SongInfo, AlbumInfo } from "../../../../../lib/Song.ts";
+import type { SongInfo } from "../../../../../lib/Song.ts";
 import type { DisplayDataRequest, RankOutput } from "../../../../../lib/Request.ts";
+import { constructQuery, processPlayedTracksData } from "../_shared/query.ts";
 
 /**
  * Handles requests for art display data, querying a user's list of played tracks and
@@ -24,21 +25,15 @@ async function handleUserDataRequest(_req: Request) {
 
   // get search filters
   let body;
-  try { body = validateDisplayDataRequest(await _req.json()); }
-  catch (error) { return new Response(error, { status: 400, headers: corsHeaders }); }
+  try {
+    body = validateDisplayDataRequest(await _req.json());
+  }
+  catch (error) {
+    return new Response(error as string, { status: 400, headers: corsHeaders });
+  }
 
   // fetch the track and album information for the current user's played tracks
-  let query = supabase
-  .from("played_tracks")
-  .select(`
-    listened_at,
-    tracks ( isrc, track_name, track_artists, track_duration_ms,
-      track_albums ( albums ( album_name, num_tracks, release_day,
-        release_month, release_year, artists, image ) )
-    )
-  `)
-  .eq("user_id", userData.user.id);
-
+  let query = constructQuery(supabase, userData.user.id);
 
   // if start date is provided, filter out listens before start date
   if (body.date.start) query = query.gte("listened_at", body.date.start);
@@ -53,37 +48,8 @@ async function handleUserDataRequest(_req: Request) {
   const { data: dbData, error } = await query;
   if (error) throw error;
 
-  const songs: SongInfo[] = [];
-  for (const entry of dbData) {
-    // the supabase api thinks that tracks() and track_albums() return an array of objects,
-    // but in reality, they only return one object. as a result, we have to do some
-    // pretty ugly typecasting to make the compiler happy
-    const track = entry.tracks as unknown as (typeof dbData)[0]["tracks"][0];
-    const album = track.track_albums[0].albums as unknown as (typeof track)["track_albums"][0]["albums"][0];
-
-    // extract album information
-    const albumInfo: AlbumInfo = {
-      title: album.album_name,
-      tracks: album.num_tracks,
-      release_day: album.release_day,
-      release_month: album.release_month,
-      release_year: album.release_year,
-      artists: album.artists,
-      image: album.image
-    };
-
-    // extract song information
-    const songInfo: SongInfo = {
-      isrc: track.isrc,
-      title: track.track_name,
-      artists: track.track_artists,
-      duration: track.track_duration_ms,
-      listened_at: entry.listened_at,
-      albums: [albumInfo]
-    };
-
-    songs.push(songInfo);
-  }
+  // process songs into SongInfo and AlbumInfo types
+  const songs = processPlayedTracksData(dbData);
 
   // filter songs by the requested number of cells if given
   let rankedSongs = rankSongs(songs, body.aggregate, body.rank_determinant);
@@ -170,7 +136,7 @@ export function validateDisplayDataRequest(req: unknown): DisplayDataRequest {
     // aggregate
     if (!("aggregate" in req)) throw "Invalid request: missing aggregate";
     if (req.aggregate !== "song" && req.aggregate !== "album")
-        throw "Invalid request: aggregate is invalid"
+        throw "Invalid request: aggregate is invalid";
 
     // num_cells
     if (!("num_cells" in req)) throw "Invalid request: missing number of cells";

--- a/docker/volumes/functions/upload-avatar/index.ts
+++ b/docker/volumes/functions/upload-avatar/index.ts
@@ -1,0 +1,73 @@
+import { corsHeaders } from "../_shared/cors.ts";
+import { log } from "../_shared/log.ts";
+import { createSbClient } from "../_shared/client.ts";
+
+/**
+ * Handles requests to upload a user's avatar image to Supabase storage.
+ * Validates the uploaded file, checking its size and type.
+ * 
+ * @param _req - The request object.
+ * @returns A response object containing either a success message or an error message.
+ */
+async function handleUploadAvatar(req: Request) {
+  // create authenticated supabase client scoped to the "public" schema
+  const authHeader = req.headers.get("Authorization")!;
+  const supabase = await createSbClient(authHeader, "public");
+  
+  // get user data
+  const { data: userData } = await supabase.auth.getUser();
+  if (!userData.user) {
+    log(4, "Unable to fetch user");
+    return new Response("Unable to fetch user",
+      { status: 401, headers: corsHeaders });
+  }
+
+  const formData = await req.formData();
+  const avatar = formData.get("avatar") as File | null;
+
+  if (!avatar) {
+    return new Response("no avatar file provided",
+      { status: 400, headers: corsHeaders });
+  }
+
+  if (avatar.size > 4 * 1024 * 1024) { // 4 MB limit
+    return new Response("uploaded file is too large. maximum size is 4MB",
+      { status: 400, headers: corsHeaders });
+  }
+
+  if (avatar.type !== "image/jpeg" && avatar.type !== "image/png") {
+    return new Response("invalid file type. only JPEG and PNG are allowed",
+      { status: 400, headers: corsHeaders });
+  }
+
+  // generate a uuid for the avatar file
+  const uuid = crypto.randomUUID();
+
+  const { error: uploadError } = await supabase.storage.from('avatars')
+    .upload(uuid, avatar);
+  if (uploadError) {
+    log(2, `Error uploading avatar: ${uploadError.message}`);
+    return new Response("server error while uploading avatar",
+      { status: 500, headers: corsHeaders },
+    );
+  }
+
+  // update the avatar URL in the user's profile
+  const { error: profileError } = await supabase
+    .from("profiles")
+    .update({ avatar_url: `assets/public/avatars/${uuid}` })
+    .eq("id", userData.user.id)
+  
+  if (profileError) {
+    log(2, `Error updating profile avatar URL: ${profileError.message}`);
+    return new Response("server error while updating profile",
+      { status: 500, headers: corsHeaders },
+    );
+  }
+
+  return new Response(
+    "successfully uploaded avatar",
+    { status: 200, headers: { ...corsHeaders } },
+  );
+}
+Deno.serve(handleUploadAvatar);


### PR DESCRIPTION
Adds an `avatars` storage bucket, security rules for accessing it, and edge functions for uploading and deleting avatars. Additionally applies some earlier refactoring to standardize querying listening data. This will have to be changed when we switch over to MusicBrainz.